### PR TITLE
Dissolve for loop to str.join

### DIFF
--- a/textflint/common/preprocess/cn_processor.py
+++ b/textflint/common/preprocess/cn_processor.py
@@ -67,6 +67,8 @@ class CnProcessor:
         if isinstance(sentence, list):
             # Turn the list into sentence
             tmp = ''.join([word for word in sentence])
+            for word in sentence:
+                tmp += word
             sentence = tmp
 
         if not sentence:
@@ -107,7 +109,9 @@ class CnProcessor:
         from ltp import LTP
         if isinstance(sentence, list):
             # Turn the list into sentence
-            tmp = ''.join([word for word in sentence])
+            tmp = ''
+            for word in sentence:
+                tmp += word
             sentence = tmp
 
         if not sentence:
@@ -138,7 +142,9 @@ class CnProcessor:
         from ltp import LTP
         if isinstance(sentence, list):
             # Turn the list into sentence
-            tmp = ''.join([word for word in sentence])
+            tmp = ''
+            for word in sentence:
+                tmp += word
             sentence = tmp
         if not sentence:
             return []

--- a/textflint/common/preprocess/cn_processor.py
+++ b/textflint/common/preprocess/cn_processor.py
@@ -142,9 +142,9 @@ class CnProcessor:
         from ltp import LTP
         if isinstance(sentence, list):
             # Turn the list into sentence
-            tmp = ''
-            for word in sentence:
-                tmp += word
+            tmp = ''.join([word for word in sentence])
+            # for word in sentence:
+            #     tmp += word
             sentence = tmp
         if not sentence:
             return []

--- a/textflint/common/preprocess/cn_processor.py
+++ b/textflint/common/preprocess/cn_processor.py
@@ -66,9 +66,7 @@ class CnProcessor:
         from ltp import LTP
         if isinstance(sentence, list):
             # Turn the list into sentence
-            tmp = ''
-            for word in sentence:
-                tmp += word
+            tmp = ''.join([word for word in sentence])
             sentence = tmp
 
         if not sentence:
@@ -109,9 +107,7 @@ class CnProcessor:
         from ltp import LTP
         if isinstance(sentence, list):
             # Turn the list into sentence
-            tmp = ''
-            for word in sentence:
-                tmp += word
+            tmp = ''.join([word for word in sentence])
             sentence = tmp
 
         if not sentence:
@@ -142,9 +138,7 @@ class CnProcessor:
         from ltp import LTP
         if isinstance(sentence, list):
             # Turn the list into sentence
-            tmp = ''
-            for word in sentence:
-                tmp += word
+            tmp = ''.join([word for word in sentence])
             sentence = tmp
         if not sentence:
             return []


### PR DESCRIPTION
It efficient to use `str.join` instead of a for loop.